### PR TITLE
Agregar hooks de git para el linter de flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: 'local'
+    hooks:
+    -   id: flake8
+        name: Flake8 checks
+        entry: flake8
+        language: system
+        args: [--config, setup.cfg]
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Are you a coding enthusiast looking to put your skills to test? Don't look more!
     pip install -r requirements-dev.txt
     ```
 
+- Setup githooks
+    ```
+    pip install pre-commit
+    pre-commit install
+    ```
+
 - Run server
 
     ```sh

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ pytest==8.1.1
 pytest-html==4.1.1
 pytest-metadata==3.1.1
 tomli==2.0.1
+pre-commit==3.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 80
+#extend-ignore = H101,H202,H233
+exclude =
+    __pycache__,
+    .venv/*


### PR DESCRIPTION
- Se agrego la libreria **pre-commit** para usar los hooks de git.
- Se agrego **.pre-commit-config.yam** donde se puede configurar los comandos a ejecutar antes de realizar el commit.
- Se agrego **setup.cfg** para configurar las reglas del linter flake8.
- Se actualizo el **README.md** para instalar la libreria pre-commit en el proyecto.